### PR TITLE
[PDXD-546] Port to driver version 2.2.0-rc3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  java:
+    version: oraclejdk8
+dependencies:
+  pre:
+      # set maven settings.xml with artifactory authentication from environment variable
+    - echo $MVN_SETTINGS_XML > ~/.m2/settings.xml
+  override:
+    - mvn deploy
+test:
+  override:
+    - echo 1 # run non-maven tests here

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.contrastsecurity</groupId>
     <artifactId>cassandra-migration</artifactId>
     <name>Cassandra Migration</name>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.7-womply-1</version>
     <description>
         Database migration tool for Cassandra
     </description>
@@ -24,14 +24,14 @@
     </organization>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>womply</id>
+            <url>https://womply.artifactoryonline.com/womply/libs-release-local</url>
         </repository>
+        <snapshotRepository>
+            <id>womply</id>
+            <url>https://womply.artifactoryonline.com/womply/libs-snapshot-local</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <scm>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.1.9</version>
+            <version>2.2.0-rc3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/contrastsecurity/cassandra/migration/action/Initialize.java
+++ b/src/main/java/com/contrastsecurity/cassandra/migration/action/Initialize.java
@@ -6,8 +6,7 @@ import com.datastax.driver.core.Session;
 
 public class Initialize {
 
-    public void run(Session session, Keyspace keyspace, String migrationVersionTableName) {
-        SchemaVersionDAO dao = new SchemaVersionDAO(session, keyspace, migrationVersionTableName);
+    public void run(SchemaVersionDAO dao) {
         dao.createTablesIfNotExist();
     }
 }

--- a/src/test/java/com/contrastsecurity/cassandra/migration/BaseIT.java
+++ b/src/test/java/com/contrastsecurity/cassandra/migration/BaseIT.java
@@ -35,7 +35,7 @@ public abstract class BaseIT {
 
     @Before
     public void createKeyspace() {
-        Statement statement = new SimpleStatement(
+        Statement statement = getSession(getKeyspace()).newSimpleStatement(
                 "CREATE KEYSPACE " + CASSANDRA__KEYSPACE +
                         "  WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };"
         );
@@ -44,7 +44,7 @@ public abstract class BaseIT {
 
     @After
     public void dropKeyspace() {
-        Statement statement = new SimpleStatement(
+        Statement statement = getSession(getKeyspace()).newSimpleStatement(
                 "DROP KEYSPACE " + CASSANDRA__KEYSPACE + ";"
         );
         getSession(getKeyspace()).execute(statement);

--- a/src/test/java/com/contrastsecurity/cassandra/migration/CassandraMigrationIT.java
+++ b/src/test/java/com/contrastsecurity/cassandra/migration/CassandraMigrationIT.java
@@ -29,6 +29,8 @@ public class CassandraMigrationIT extends BaseIT {
 		cm.setKeyspace(getKeyspace());
 		cm.migrate();
 
+		QueryBuilder queryBuilder = new QueryBuilder(getSession().getCluster());
+
 		MigrationInfoService infoService = cm.info();
 		System.out.println("Initial migration");
 		System.out.println(MigrationInfoDumper.dumpToAsciiTable(infoService.all()));
@@ -40,7 +42,7 @@ public class CassandraMigrationIT extends BaseIT {
 				assertThat(info.getType().name(), is(MigrationType.JAVA_DRIVER.name()));
 				assertThat(info.getScript().contains(".java"), is(true));
 
-				Select select = QueryBuilder.select().column("value").from("test1");
+				Select select = queryBuilder.select().column("value").from("test1");
 				select.where(eq("space", "web")).and(eq("key", "facebook"));
 				ResultSet result = getSession().execute(select);
 				assertThat(result.one().getString("value"), is("facebook.com"));
@@ -49,7 +51,7 @@ public class CassandraMigrationIT extends BaseIT {
 				assertThat(info.getType().name(), is(MigrationType.JAVA_DRIVER.name()));
 				assertThat(info.getScript().contains(".java"), is(true));
 
-				Select select = QueryBuilder.select().column("value").from("test1");
+				Select select = queryBuilder.select().column("value").from("test1");
 				select.where(eq("space", "web")).and(eq("key", "google"));
 				ResultSet result = getSession().execute(select);
 				assertThat(result.one().getString("value"), is("google.com"));
@@ -58,7 +60,7 @@ public class CassandraMigrationIT extends BaseIT {
 				assertThat(info.getType().name(), is(MigrationType.CQL.name()));
 				assertThat(info.getScript().contains(".cql"), is(true));
 
-				Select select = QueryBuilder.select().column("title").column("message").from("contents");
+				Select select = queryBuilder.select().column("title").column("message").from("contents");
 				select.where(eq("id", 1));
 				Row row = getSession().execute(select).one();
 				assertThat(row.getString("title"), is("foo"));
@@ -68,7 +70,7 @@ public class CassandraMigrationIT extends BaseIT {
 				assertThat(info.getType().name(), is(MigrationType.CQL.name()));
 				assertThat(info.getScript().contains(".cql"), is(true));
 
-				Select select = QueryBuilder.select().column("value").from("test1");
+				Select select = queryBuilder.select().column("value").from("test1");
 				select.where(eq("space", "foo")).and(eq("key", "bar"));
 				ResultSet result = getSession().execute(select);
 				assertThat(result.one().getString("value"), is("profit!"));

--- a/src/test/java/migration/integ/java/V3_0_1__Three_zero_one.java
+++ b/src/test/java/migration/integ/java/V3_0_1__Three_zero_one.java
@@ -8,7 +8,8 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 public class V3_0_1__Three_zero_one implements JavaMigration {
     @Override
     public void migrate(Session session) throws Exception {
-        Insert insert = QueryBuilder.insertInto("test1");
+        QueryBuilder queryBuilder = new QueryBuilder(session.getCluster());
+        Insert insert = queryBuilder.insertInto("test1");
         insert.value("space", "web");
         insert.value("key", "facebook");
         insert.value("value", "facebook.com");

--- a/src/test/java/migration/integ/java/V3_0__Third.java
+++ b/src/test/java/migration/integ/java/V3_0__Third.java
@@ -9,7 +9,8 @@ public class V3_0__Third implements JavaMigration {
 
     @Override
     public void migrate(Session session) throws Exception {
-        Insert insert = QueryBuilder.insertInto("test1");
+        QueryBuilder queryBuilder = new QueryBuilder(session.getCluster());
+        Insert insert = queryBuilder.insertInto("test1");
         insert.value("space", "web");
         insert.value("key", "google");
         insert.value("value", "google.com");


### PR DESCRIPTION
- Ports the cassandra-migrations library to use the 2.2.0-rc3 driver to match what we use in the rest of our codebase.
- Adds necessary meta-information to publish to womply repos
