### PR TITLE
V0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.contrastsecurity</groupId>
     <artifactId>cassandra-migration</artifactId>
     <name>Cassandra Migration</name>
-    <version>0.7-womply-3</version>
+    <version>0.8-womply</version>
     <description>
         Database migration tool for Cassandra
     </description>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.contrastsecurity</groupId>
     <artifactId>cassandra-migration</artifactId>
     <name>Cassandra Migration</name>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.7</version>
     <description>
         Database migration tool for Cassandra
     </description>
@@ -38,7 +38,7 @@
         <url>https://github.com/Contrast-Security-OSS/cassandra-migration</url>
         <connection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</connection>
         <developerConnection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>cassandra-migration-0.7</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.contrastsecurity</groupId>
     <artifactId>cassandra-migration</artifactId>
     <name>Cassandra Migration</name>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.8</version>
     <description>
         Database migration tool for Cassandra
     </description>
@@ -38,7 +38,7 @@
         <url>https://github.com/Contrast-Security-OSS/cassandra-migration</url>
         <connection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</connection>
         <developerConnection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>cassandra-migration-0.8</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.contrastsecurity</groupId>
     <artifactId>cassandra-migration</artifactId>
     <name>Cassandra Migration</name>
-    <version>0.7</version>
+    <version>0.8-SNAPSHOT</version>
     <description>
         Database migration tool for Cassandra
     </description>
@@ -38,7 +38,7 @@
         <url>https://github.com/Contrast-Security-OSS/cassandra-migration</url>
         <connection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</connection>
         <developerConnection>scm:git:https://github.com/Contrast-Security-OSS/cassandra-migration.git</developerConnection>
-        <tag>cassandra-migration-0.7</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
```
This is a breaking changeset.

To support cassandra 3, we need to upgrade the schema migrator and the
driver version.  This requires removing a the CustomReflectionMapper and
as such will break the functionality that avoids tombstones in Optional
storage.

This also removes the single-mode setting in cassandra-migration,
delegating to the upstream implementation.  Clusters with a
single node are automatically set to consistency ONE.

Finally, the schema initialization hook removed the interface for
InitializationHook because that drags in
womply-common-dropwizard-service dependencies in as well.
```